### PR TITLE
feat: Support pour un path de vault personnalisés

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -57,8 +57,6 @@ help [command]
 
 - **Multi-notes** : Permettre d'avoir plus d'un message par entrée.
 
-- **Support multi-vault** : Permettre la création et la gestion de plusieurs fichiers de coffre-fort indépendants.
-
 ## Ce que j'ai appris
 - **Authenticité (AEAD)** : Utilisation d'AES-256-GCM pour garantir que les secrets n'ont pas été altérés ou corrompus sur le disque.
 

--- a/README.MD
+++ b/README.MD
@@ -25,16 +25,16 @@ Un gestionnaire de secrets en ligne de commande (CLI) écrit en Rust. Ce projet 
 #### **Ajouter une entrée**  
 Dans le cas où l'entrée existe déjà, le programme va afficher un avertissement et demander une confirmation avant d'écraser l'entrée déjà existante.
 ```
-add <label>
+add <label> [-p|--path <path>]
 ```
 #### **Lire une entrée**
 ```
-read <label>
+read <label> [-p|--path <path>]
 ```
 #### **Supprimer une entrée**
 Contrairement aux autres commandes, delete ne requiert pas le mot de passe fourni lors de la création de l'entrée, étant donné que les secrets sont enregistrés localement sur le disque. Ainsi, il est très facile de directement supprimer le fichier de secrets sans passer le terminal. Par conséquent, demander le mot de passe avant de supprimer une entrée serait une "couche de sécurité" placebo.
 ```
-delete <label>
+delete <label> [-p|--path <path>]
 ```
 #### **Message d'aide**
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,14 @@
 use clap::{Parser, Subcommand};
 
+pub const DEFAULT_PATH: &str = "vault.json";
+
 #[derive(Parser)]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
+
+    #[arg(short, long, global=true, default_value=DEFAULT_PATH)]
+    pub path: String,
 }
 
 #[derive(Subcommand, Clone)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,7 @@ pub struct Cli {
 
 #[derive(Subcommand, Clone)]
 pub enum Commands {
-    /// Add or overwrite an entry
+    /// Add or overwrite an entry. If the file doesn't already exist, a file will be created.
     Add {
         label: String,
     },

--- a/src/json_vault.rs
+++ b/src/json_vault.rs
@@ -5,8 +5,6 @@ use std::fs;
 use std::path::Path;
 use std::collections::HashMap;
 
-const PATH: &str = "vault.json";
-
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Entry {
@@ -18,10 +16,10 @@ pub struct Entry {
     pub cipher_text: Vec<u8>,
 }
 
-pub fn open_vault() -> anyhow::Result<HashMap<String, Entry>> {
-    let path = Path::new(PATH);
+pub fn open_vault(path: &String) -> anyhow::Result<HashMap<String, Entry>> {
+    let path = Path::new(&path);
     if path.exists() {
-        let file_content = fs::read_to_string(&PATH)
+        let file_content = fs::read_to_string(&path)
             .context("Failed to read the vault file")?;
         let entries = serde_json::from_str(&file_content)
             .context("Vault file is corrupted or is not valid JSON")?;
@@ -31,10 +29,10 @@ pub fn open_vault() -> anyhow::Result<HashMap<String, Entry>> {
     }
 }
 
-pub fn write_vault(entries: HashMap<String, Entry>) -> anyhow::Result<()> {
+pub fn write_vault(path: &String, entries: HashMap<String, Entry>) -> anyhow::Result<()> {
     let json_string = serde_json::to_string_pretty(&entries)
         .context("Failed to serialize the vault entries")?;
-    fs::write(&PATH, json_string)
+    fs::write(path, json_string)
         .context("Failed to save the vault file to disk")?;
     Ok(())
 }

--- a/src/json_vault.rs
+++ b/src/json_vault.rs
@@ -31,6 +31,9 @@ pub fn open_vault(path: &PathBuf) -> anyhow::Result<HashMap<String, Entry>> {
 pub fn write_vault(path: PathBuf, entries: HashMap<String, Entry>) -> anyhow::Result<()> {
     let json_string = serde_json::to_string_pretty(&entries)
         .context("Failed to serialize the vault entries")?;
+
+    if !path.exists() { println!("No vault at the path {path:?} exists, a new vault is going to be created") }
+
     fs::write(path, json_string)
         .context("Failed to save the vault file to disk")?;
     Ok(())

--- a/src/json_vault.rs
+++ b/src/json_vault.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use serde::{Serialize, Deserialize};
 use serde_with::{serde_as, base64::Base64};
 use std::fs;
-use std::path::Path;
+use std::path::PathBuf;
 use std::collections::HashMap;
 
 #[serde_as]
@@ -16,8 +16,7 @@ pub struct Entry {
     pub cipher_text: Vec<u8>,
 }
 
-pub fn open_vault(path: &String) -> anyhow::Result<HashMap<String, Entry>> {
-    let path = Path::new(&path);
+pub fn open_vault(path: &PathBuf) -> anyhow::Result<HashMap<String, Entry>> {
     if path.exists() {
         let file_content = fs::read_to_string(&path)
             .context("Failed to read the vault file")?;
@@ -29,7 +28,7 @@ pub fn open_vault(path: &String) -> anyhow::Result<HashMap<String, Entry>> {
     }
 }
 
-pub fn write_vault(path: &String, entries: HashMap<String, Entry>) -> anyhow::Result<()> {
+pub fn write_vault(path: PathBuf, entries: HashMap<String, Entry>) -> anyhow::Result<()> {
     let json_string = serde_json::to_string_pretty(&entries)
         .context("Failed to serialize the vault entries")?;
     fs::write(path, json_string)

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,10 @@ fn main() -> anyhow::Result<()> {
             println!("Entry '{label}' was successfully saved")
         }
         Commands::Delete { label } => {
+            if !&path.exists() {
+                return Err(anyhow!("Failed to delete entry '{label}', because no vault file was found at path: {path:?}"));
+            }
+
             if delete_entry(&mut entries, String::from(label)) {
                 write_vault(path, entries)
                     .context("Failed to save the vault to disk")?;
@@ -71,6 +75,10 @@ fn main() -> anyhow::Result<()> {
             }
         }
         Commands::Read { label } => {
+            if !path.exists() {
+                return Err(anyhow!("Failed to read entry '{label}', because no vault file was found at path: {path:?}"));
+            }
+
             let Some(entry) = read_entry(&entries, &label) else {
                 return Err(anyhow!("Entry '{label}' does not exists, nothing to read"));
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,17 +4,18 @@ mod crypto;
 
 use anyhow::{Context, anyhow};
 use clap::Parser;
+use std::path::PathBuf;
 use rpassword::prompt_password;
 
 use cli::{Cli, Commands, DEFAULT_PATH};
 use json_vault::{Entry, open_vault, write_vault, add_entry, delete_entry, read_entry};
 use crypto::{cipher, decipher};
 
-fn handle_path(path: String) -> String {
+fn handle_path(path: String) -> PathBuf {
     if path == DEFAULT_PATH {
-        String::from(DEFAULT_PATH)
+        PathBuf::from(DEFAULT_PATH)
     } else {
-        path
+        PathBuf::from(&path)
     }
 }
 
@@ -56,13 +57,13 @@ fn main() -> anyhow::Result<()> {
                 .context("Failed to create a new entry")?;
             add_entry(&mut entries, String::from(label), entry);
             
-            write_vault(&path, entries)
+            write_vault(path, entries)
                 .context("Failed to save the vault to disk")?;
             println!("Entry '{label}' was successfully saved")
         }
         Commands::Delete { label } => {
             if delete_entry(&mut entries, String::from(label)) {
-                write_vault(&path, entries)
+                write_vault(path, entries)
                     .context("Failed to save the vault to disk")?;
                 println!("Entry '{label}' was correctly deleted");
             } else {


### PR DESCRIPTION
Implémentation de la fonctionnalité de gestion multi-vault. C'est maintenant possible de spécifier un path pour chaque commande (`add`, `delete` et `read`).

### Modifications principales :
**src/cli.rs** : Ajout de l'argument optionnel non-positionnel path avec la valeur par défaut vault.json.

**src/main.rs** : Ajout d'une fonction handle_path pour la conversion du path de String vers PathBuf et ajout de vérifications d'existence du vault pour les commandes Read et Delete afin de clarifier le message d'erreur (dire que le fichier n'existe pas au lieu que juste dire que l'entrée n'existe pas)

**src/json_vault.rs** : Refactorisation des fonctions de gestion de vault pour utiliser PathBuf au lieu d'une String.

close #1 